### PR TITLE
2 simplifications to python examples

### DIFF
--- a/beginners/examples/arrays.py
+++ b/beginners/examples/arrays.py
@@ -8,10 +8,10 @@ a_in, a_out = Consts("a_in, a_out", array)
 
 s = SolverFor('QF_AX')
 
-s.add(tmp == (Select(a_in, i)))
-s.add(a_out == (Store(Store(a_in, i, Select(a_in, j)), 
+s.add(tmp == a_in[i])
+s.add(a_out == (Store(Store(a_in, i, a_in[j]), 
     j, tmp)))
-s.add((Select(a_in, i)) == (Select(a_in, j)))
+s.add(a_in[i] == a_in[j])
 s.add(a_in != a_out)
 
 print(s.check())

--- a/beginners/examples/fields.py
+++ b/beginners/examples/fields.py
@@ -1,6 +1,5 @@
 from cvc5.pythonic import *
-F = FiniteFieldSort(13)
-x, y = FiniteFieldElems("x y", F)
+x, y = FiniteFieldElems("x y", 13)
 s = SolverFor("QF_FF")
 s.add(x + y == 1)
 s.add(x * y == 1)

--- a/beginners/solutions/Exercise12.py
+++ b/beginners/solutions/Exercise12.py
@@ -1,6 +1,5 @@
 from cvc5.pythonic import *
-F = FiniteFieldSort(13)
-x, y = FiniteFieldElems("x y", F)
+x, y = FiniteFieldElems("x y", 13)
 s = SolverFor("QF_FF")
 s.add(x * x == y)
 s.add(y * y == 1)

--- a/beginners/solutions/Exercise6.py
+++ b/beginners/solutions/Exercise6.py
@@ -8,10 +8,10 @@ a_in, a_out = Consts("a_in, a_out", array)
 
 s = SolverFor('QF_AX')
 
-s.add(tmp == (Select(a_in, i)))
-s.add(a_out == (Store(Store(a_in, i, Select(a_in, j)), 
-    j, tmp)))
-s.add((Select(a_in, i)) != (Select(a_in, j)))
+s.add(tmp == a_in[i])
+s.add(a_out == Store(Store(a_in, i, a_in[j]), 
+    j, tmp))
+s.add(a_in[i] != a_in[j])
 s.add(a_in == a_out)
 
 print(s.check())


### PR DESCRIPTION
1. when declaring a ff variable, we don't need to create a sort. Giving the order of the field is enough.
2. the pythonic interface understands a[i] for arrays, so no need to use `Select` at all.